### PR TITLE
Ajout du nom de naissance dans le RP

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/Proprietaire.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/Proprietaire.java
@@ -7,6 +7,8 @@ public class Proprietaire {
 	private String compteCommunal;
 	
 	private String nom;
+	
+	private String nomNaissance;
 		
 	private String adresse;
 	
@@ -32,6 +34,21 @@ public class Proprietaire {
 	 */
 	public void setNom(String nom) {
 		this.nom = nom;
+	}
+	
+	/**
+	 * @return the nom
+	 */
+	public String getNomNaissance() {
+		return nomNaissance;
+	}
+
+	@XmlAttribute
+	/**
+	 * @param nom the nom to set
+	 */
+	public void setNomNaissance(String nomNaissance) {
+		this.nomNaissance = nomNaissance;
 	}
 
 	

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/ReleveProprieteHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/ReleveProprieteHelper.java
@@ -145,7 +145,7 @@ public final class ReleveProprieteHelper extends CadController{
 						List<Proprietaire> proprietaires = new ArrayList<Proprietaire>();
 
 						StringBuilder queryBuilderProprietaire = new StringBuilder();
-						queryBuilderProprietaire.append("select prop.comptecommunal, prop.dnulp, prop.ccodem_lib, prop.dldnss, prop.jdatnss,  prop.ccodro_lib, app_nom_usage as nom, COALESCE(prop.dlign3, '')||' '||COALESCE(prop.dlign4,'')||' '||COALESCE(prop.dlign5,'')||' '||COALESCE(prop.dlign6,'') as adresse ");
+						queryBuilderProprietaire.append("select prop.comptecommunal, prop.dnulp, prop.ccodem_lib, prop.dldnss, prop.jdatnss,  prop.ccodro_lib, app_nom_usage as nom, app_nom_naissance as nom_naissance, COALESCE(prop.dlign3, '')||' '||COALESCE(prop.dlign4,'')||' '||COALESCE(prop.dlign5,'')||' '||COALESCE(prop.dlign6,'') as adresse ");
 						queryBuilderProprietaire.append("from ");
 						queryBuilderProprietaire.append(databaseSchema);
 						queryBuilderProprietaire.append(".proprietaire prop ");
@@ -164,6 +164,7 @@ public final class ReleveProprieteHelper extends CadController{
 
 							Proprietaire proprietaire = new Proprietaire();
 							proprietaire.setNom((String) prop.get("nom"));
+							proprietaire.setNomNaissance((String) prop.get("nom_naissance"));
 							proprietaire.setAdresse((String) prop.get("adresse"));
 							proprietaire.setCodeDeDemenbrement((String) prop.get("ccodem_lib"));
 							proprietaire.setDateNaissance((String) prop.get("jdatnss"));

--- a/cadastrapp/src/main/resources/xsl/relevePropriete.xsl
+++ b/cadastrapp/src/main/resources/xsl/relevePropriete.xsl
@@ -174,12 +174,12 @@
 							</fo:block>
 						</fo:table-cell>
 						<fo:table-cell xsl:use-attribute-sets="bordure-left">
-							<fo:block padding-top="5pt">
+							<fo:block>
 								<xsl:value-of select="@adresse" />
 							</fo:block>
 						</fo:table-cell>
 						<fo:table-cell xsl:use-attribute-sets="bordure-left">
-							<fo:block padding-top="5pt">
+							<fo:block>
 								<xsl:if test="@dateNaissance or @lieuNaissance">
 									Né(e)
 								</xsl:if>
@@ -190,6 +190,10 @@
 								<xsl:if test="@lieuNaissance">
 									à
 									<xsl:value-of select="@lieuNaissance" />
+								</xsl:if>
+								<xsl:if test="@nomNaissance">
+									&#x2028;
+									<xsl:value-of select="@nomNaissance" />
 								</xsl:if>
 							</fo:block>
 						</fo:table-cell>


### PR DESCRIPTION
Ajout du nom de naissance dans la 3e colonne des proprietaires dans les RP commue vu dans https://github.com/georchestra/cadastrapp/issues/249